### PR TITLE
fix missing include of QDebug with Qt 5.12.8

### DIFF
--- a/LVGLProperty.cpp
+++ b/LVGLProperty.cpp
@@ -5,6 +5,7 @@
 #include <QComboBox>
 #include <QLineEdit>
 #include <QSpinBox>
+#include <QDebug>
 
 #include "LVGLObject.h"
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Tested:
  * Windows 10 + MSVC 2019 + Qt 5.15.1
  * Windows 10 + MinGW 8.1 + Qt 5.15.2
  * Ubuntu 18.04.4 + Qt 5.14.2
+ * Ubuntu 20.04 + Qt 5.12.8
 
 ### Build
 Building with console:


### PR DESCRIPTION
This PR fixes the issue #10.
Haven't tried with more recent versions of Qt. As it is just an `include`, I assume it won't break builds with other versions.